### PR TITLE
Fixed bug causes when raising override cycles error

### DIFF
--- a/lambdas/layers/umccr_utils/api.py
+++ b/lambdas/layers/umccr_utils/api.py
@@ -1,6 +1,7 @@
 import requests
 import os
 
+
 def get_metadata(sample_id_var, library_id_var, auth_header):
 
   query_str_api = "{} {}".format(sample_id_var, library_id_var)
@@ -17,6 +18,7 @@ def get_metadata(sample_id_var, library_id_var, auth_header):
   data_portal_metadata_api = os.environ["data_portal_domain_name"]
 
   metadata_api = "https://" + data_portal_metadata_api + "/metadata"
+
   # API call
   response = requests.get(metadata_api,
     params=parameter,
@@ -27,7 +29,6 @@ def get_metadata(sample_id_var, library_id_var, auth_header):
 
   # Raise an error for non 200 status code
   if response.status_code < 200 or response.status_code >= 300:
-    print(data)
     raise ValueError
 
   


### PR DESCRIPTION
Error fixed is: `Error: object of type 'int' has no len().`

Also fixed issue where samples shown to suggest one cycle count over another are now shown.