### PR TITLE
Sanitize and Improve batch API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,22 @@ sample_sheet = SampleSheet(sample_sheet_path)
 run_sample_sheet_content_check(sample_sheet)
 
 # Check 2
-run_sample_sheet_check_with_metadata(sample_sheet, auth_header)
+async def set_and_check_metadata(sample_sheet, auth_header):
+    # Set metadata
+    loop = asyncio.get_running_loop()
+    error = await asyncio.gather(
+        sample_sheet.set_metadata_df_from_api(auth_header, loop),
+    )
+    
+    # run metadta check
+    run_sample_sheet_check_with_metadata(sample_sheet)
+    
+loop = asyncio.new_event_loop()
+set_and_check_metadata(sample_sheet, auth_header):
+loop.close()
+
+    
+
 
 EOF
 

--- a/lambdas/layers/umccr_utils/umccr_utils/api.py
+++ b/lambdas/layers/umccr_utils/umccr_utils/api.py
@@ -17,32 +17,45 @@ async def get_metadata_record_from_array_of_field_name(auth_header: str, path: s
 
     # Removing any duplicates for api efficiency
     value_list = list(set(value_list))
-    
-    # Define query string
-    query_param_string = f'&{field_name}='.join(value_list)
-    query_param_string = f'?{field_name}=' + query_param_string  # Appending name at the beginning
 
-    query_param_string = query_param_string + f'&rowsPerPage=1000'  # Add Rows per page (1000 is the maximum rows)
-
-    url = "https://" + DATA_PORTAL_DOMAIN_NAME + "/" + path.strip('/') + query_param_string
-
+    # Result variable
     query_result = []
-    print('Start API request')
+
     async with ClientSession() as session:
 
-        # Make sure no data is left, looping data until the end
-        while url is not None:
+        # Set maximum batch API call to 300 to prevent "Request Header Fields Too Large"
+        max_number_of_library_per_api_call = 300
+        for i in range(0, len(value_list), max_number_of_library_per_api_call):
 
-            async with session.get(url, headers=headers) as response:
+            # Define start and stop element from the list
+            start_index = i
+            end_index = start_index + max_number_of_library_per_api_call
 
-                # API call
-                response_json = await response.json()
+            array_to_process = value_list[start_index:end_index]
 
-                # Raise an error for non 200 status code
-                if response.status < 200 or response.status >= 300:
-                    raise ValueError(f'Non 20X status code returned')
+            print(len(array_to_process))
 
-                query_result.extend(response_json["results"])
-                url = response_json["links"]["next"]
-    print('Finish API request')
+            # Define query string
+            query_param_string = f'&{field_name}='.join(array_to_process)
+            query_param_string = f'?{field_name}=' + query_param_string  # Appending name at the beginning
+
+            query_param_string = query_param_string + f'&rowsPerPage=1000'  # Add Rows per page (1000 is the maximum rows)
+
+            url = "https://" + DATA_PORTAL_DOMAIN_NAME + "/" + path.strip('/') + query_param_string
+
+            # Make sure no data is left, looping data until the end
+            while url is not None:
+
+                async with session.get(url, headers=headers) as response:
+
+                    # API call
+                    response_json = await response.json()
+
+                    # Raise an error for non 200 status code
+                    if response.status < 200 or response.status >= 300:
+                        raise ValueError(f'Non 20X status code returned')
+
+                    query_result.extend(response_json["results"])
+                    url = response_json["links"]["next"]
+
     return query_result

--- a/lambdas/layers/umccr_utils/umccr_utils/api.py
+++ b/lambdas/layers/umccr_utils/umccr_utils/api.py
@@ -15,6 +15,9 @@ async def get_metadata_record_from_array_of_field_name(auth_header: str, path: s
         'Authorization': auth_header
     }
 
+    # Removing any duplicates for api efficiency
+    value_list = list(set(value_list))
+    
     # Define query string
     query_param_string = f'&{field_name}='.join(value_list)
     query_param_string = f'?{field_name}=' + query_param_string  # Appending name at the beginning

--- a/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py
+++ b/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py
@@ -257,7 +257,7 @@ class SampleSheet:
                                                                                    field_name='library_id',
                                                                                    value_list=library_id_array)
 
-        except ValueError:
+        except Exception as e:
             logger.error("Fail to fetch metadata api for library id in the samplesheet")
             raise ApiCallError
 

--- a/stacks/sscheck_backend_stack.py
+++ b/stacks/sscheck_backend_stack.py
@@ -79,7 +79,7 @@ class SampleSheetCheckBackEndStack(cdk.Stack):
             code=lambda_.Code.from_asset("lambdas/functions"),
             handler="main.lambda_handler",
             layers=[sample_check_layer, runtime_library_layer],
-            memory_size=256,
+            memory_size=2048,
             environment={"data_portal_domain_name": data_portal_domain_name}
         )
 


### PR DESCRIPTION
- Remove duplicate libraries before batch API call
- Only allow max 300 libraries per batch API call (putting it into for loop)
- Readme update
- Bump lambda memory