### PR TITLE
Updated checks and logging

### DIFF
--- a/lambdas/functions/samplesheet_check.py
+++ b/lambdas/functions/samplesheet_check.py
@@ -13,6 +13,7 @@ from umccr_utils.samplesheet import set_meta_data_by_library_id
 # Errors
 from umccr_utils.errors import GetMetaDataError, SampleSheetHeaderError, SimilarIndexError, \
     SampleNameFormatError, MetaDataError, OverrideCyclesError
+import pandas as pd
 
 # Logger
 logger = set_basic_logger()
@@ -105,6 +106,12 @@ def run_sample_sheet_check_with_metadata(sample_sheet):
         check_global_override_cycles(sample_sheet)
         print('----------check_internal_override_cycles----------')
         check_internal_override_cycles(sample_sheet)
+        logger.info("Printing the value_counts of the samplesheet (by assay, type and override cycles)")
+        sample_sheet_df = pd.DataFrame([{"assay": sample.library_series['assay'],
+                                         "type": sample.library_series['type'],
+                                         "override_cycles": sample.library_series['override_cycles']}
+                                         for sample in sample_sheet])
+        logger.info(f"Value Counts:\n{sample_sheet_df.value_counts()}")
 
     except SampleNameFormatError:
         logger.error("Sample name was not appropriate.")

--- a/lambdas/layers/umccr_utils/umccr_utils/api.py
+++ b/lambdas/layers/umccr_utils/umccr_utils/api.py
@@ -3,6 +3,7 @@ import os
 from aiohttp import ClientSession
 import requests
 from typing import List
+from urllib.parse import urlparse
 
 # Grab api constant from environment variable
 DATA_PORTAL_DOMAIN_NAME = os.environ["data_portal_domain_name"]
@@ -41,7 +42,10 @@ async def get_metadata_record_from_array_of_field_name(auth_header: str, path: s
 
             query_param_string = query_param_string + f'&rowsPerPage=1000'  # Add Rows per page (1000 is the maximum rows)
 
-            url = "https://" + DATA_PORTAL_DOMAIN_NAME + "/" + path.strip('/') + query_param_string
+            if not urlparse(DATA_PORTAL_DOMAIN_NAME).scheme == "":
+                url = DATA_PORTAL_DOMAIN_NAME + "/" + path.strip('/') + query_param_string
+            else:
+                url = "https://" + DATA_PORTAL_DOMAIN_NAME + "/" + path.strip('/') + query_param_string
 
             # Make sure no data is left, looping data until the end
             while url is not None:

--- a/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py
+++ b/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py
@@ -777,8 +777,11 @@ def check_global_override_cycles(samplesheet):
                     [sample.sample_id
                      for sample in samplesheet
                      if sample.read_cycle_counts[read_index] == num_cycles]
-                logger.error("The following samples have this this read count for this read index section: {}\nSamples: {}".
+                logger.error("The following samples have this this read count for this read index section: {}\n"
+                             "CycleCount: {}\n"
+                             "Samples: {}".
                              format(read_index+1,
+                                    num_cycles,
                                     ", ".join(map(str, samples_with_this_cycle_count_in_this_read_index_section))))
             raise OverrideCyclesError
         else:


### PR DESCRIPTION
## Changes

* api.py
  * Added option for data_portal_domain_name to be a local link (when running data-portal locally, the link is `http://data.localhost:8000`.  

* samplesheet_check.py
  * Added value_counts of assay/type and override cycles at info level to the end of the samplesheet checker 


* samplesheet.py
  * Added in check to make sure regex object of sample and library are not none and error gracefully with logs if so

  * If subject id is not present, raise error, not warning

  * Exit gracefully in override cycles section if the readcounts for a sample doesn't match the rest of the samples


## Examples

###  Checker fails when subject id is not present in lab metadata
```
2022-03-01 01:04:24,843 - ERROR    - samplesheet               - check_metadata_correspondence            : LineNo. 558  - No subject ID for PRJ211234
2022-03-01 01:04:24,843 - ERROR    - samplesheet_check         - run_sample_sheet_check_with_metadata     : LineNo. 131  - Unknown samplesheet error. Error:
Test complete!
```

### Value Counts of assay, type and override cycles now added to end of the logs (at INFO) level:
```
2022-03-01 00:58:27,184 - INFO     - samplesheet_check         - run_sample_sheet_check_with_metadata     : LineNo. 116  - Value Counts:
assay    type   override_cycles
NebRNA   WTS    Y151;I8;I8;Y151            16
TsqNano  WGS    Y151;I8;I8;Y151            14
ctTSO    ctDNA  U7N1Y143;I8;I8;U7N1Y143     1
dtype: int64
Test complete!
```

### Checker now errors gracefully when override cycles don't match up:
```
2022-03-01 01:37:38,555 - ERROR    - samplesheet               - check_global_override_cycles             : LineNo. 785  - The following samples have this this read count for this read index section: 4
CycleCount: 150
Samples: PRJ211234
2022-03-01 01:37:38,555 - ERROR    - samplesheet               - check_global_override_cycles             : LineNo. 785  - The following samples have this this read count for this read index section: 4
CycleCount: 151
Samples: MDX210471, MDX210472, PRJ211229, PRJ211230, PRJ211232, PRJ211233, PRJ211235, PRJ211236, PRJ211222, PRJ210922, PRJ210923, PRJ210931, PRJ210934, PRJ211139, MDX210374, MDX210473, PRJ211195, PRJ211196, PRJ211197, PRJ211231, PRJ211237, PTC_NebRNA211214, MDX210372, MDX210465, MDX210475, PRJ210952, PRJ210966, PRJ211198, NTC_NebRNA211214, PRJ210166
2022-03-01 01:37:38,555 - ERROR    - samplesheet_check         - run_sample_sheet_check_with_metadata     : LineNo. 125  - Override cycles check failed
Test complete!
```

### Checker now fails verbosely when a sample-name / library name combo in the samplesheet doesn't have the right regex:

Was:
```
Running samplesheet 'SampleSheet.csv' through check script 'lambdas/functions/samplesheet_check.py'
Traceback (most recent call last):
  File "/tmp/tmp.CMtilYJj4j", line 20, in <module>
    sample_sheet = SampleSheet(sample_sheet_path)
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 229, in __init__
    self.read()
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 344, in read
    self.convert_data_to_samples()
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 375, in convert_data_to_samples
    else None
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 74, in __init__
    self.set_sample_id_and_library_id_from_unique_id()
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 97, in set_sample_id_and_library_id_from_unique_id
    self.sample_id = unique_id_regex_obj.group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```

Now:
```
Running samplesheet 'SampleSheet.csv' through check script 'lambdas/functions/samplesheet_check.py'
2022-03-01 01:08:36,589 - ERROR    - samplesheet               - set_sample_id_and_library_id_from_unique_id : LineNo. 98   - Could not split sample and library id from PRJ2112345_L2101763
Traceback (most recent call last):
  File "/tmp/tmp.BTHrd7JmQc", line 20, in <module>
    sample_sheet = SampleSheet(sample_sheet_path)
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 234, in __init__
    self.read()
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 349, in read
    self.convert_data_to_samples()
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 380, in convert_data_to_samples
    else None
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 74, in __init__
    self.set_sample_id_and_library_id_from_unique_id()
  File "/home/ec2-user/samplesheet-check-backend/lambdas/layers/umccr_utils/umccr_utils/samplesheet.py", line 99, in set_sample_id_and_library_id_from_unique_id
    raise SampleNameFormatError
umccr_utils.errors.SampleNameFormatError
```